### PR TITLE
Feature/remove datomic

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,12 +1,13 @@
 {:paths   ["src"]
  :deps    {edn-query-language/eql   {:mvn/version "0.0.9"}
-           aysylu/loom              {:mvn/version "1.0.2"}
-           com.datomic/datomic-free {:mvn/version "0.9.5697"
-                                     :exclusions  [commons-codec
-                                                   joda-time]}}
+           aysylu/loom              {:mvn/version "1.0.2"}}
+
  :aliases {:provided {:extra-deps {org.clojure/clojure       {:mvn/version "1.10.1"}
                                    org.clojure/clojurescript {:mvn/version "1.10.597"}}}
            :test     {:extra-paths ["test" "dev"]
-                      :extra-deps  {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                      :extra-deps  {com.datomic/datomic-free {:mvn/version "0.9.5697"
+                                                              :exclusions [joda-time
+                                                                           commons-codec]}
+                                    com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
                                                                :sha     "f7ef16dc3b8332b0d77bc0274578ad5270fbfedd"}}
                       :main-opts   ["-m" "cognitect.test-runner"]}}}

--- a/src/pour/core.clj
+++ b/src/pour/core.clj
@@ -1,10 +1,9 @@
 (ns pour.core
   (:require [edn-query-language.core :as eql])
-  (:import (clojure.lang Seqable)
-           (datomic Entity)))
+  (:import (clojure.lang Seqable)))
 
 (defn seqy? [s]
-  (and (not (instance? Entity s))
+  (and (not (:db/id s)) ; ie, a datomic Entity or similar
        (not (map? s))
        (instance? Seqable s)))
 

--- a/test/pour/core_test.clj
+++ b/test/pour/core_test.clj
@@ -6,6 +6,7 @@
 (defrecord Test [a b])
 
 (deftest seqy
+  (is (not (pour/seqy? {:db/id 123})))
   (is (not (pour/seqy? {})))
   (is (not (pour/seqy? nil)))
   (is (not (pour/seqy? "hi")))


### PR DESCRIPTION
- Contributes to #9 
- Remove runtime dependency on `datomic-free`
- Keep it in for tests so we can keep asserting on actual, real entities.