### PR TITLE
retire futures in favour of core async

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,14 @@
 {:paths   ["src"]
- :deps    {edn-query-language/eql   {:mvn/version "0.0.9"}
-           aysylu/loom              {:mvn/version "1.0.2"}}
+ :deps    {edn-query-language/eql {:mvn/version "1.0.0"}
+           org.clojure/core.async {:mvn/version "1.3.610"}
+           aysylu/loom            {:mvn/version "1.0.2"}}
 
  :aliases {:provided {:extra-deps {org.clojure/clojure       {:mvn/version "1.10.1"}
-                                   org.clojure/clojurescript {:mvn/version "1.10.597"}}}
+                                   org.clojure/clojurescript {:mvn/version "1.10.773"}}}
            :test     {:extra-paths ["test" "dev"]
-                      :extra-deps  {com.datomic/datomic-free {:mvn/version "0.9.5697"
-                                                              :exclusions [joda-time
-                                                                           commons-codec]}
+                      :extra-deps  {com.datomic/datomic-free  {:mvn/version "0.9.5697"
+                                                               :exclusions  [joda-time
+                                                                             commons-codec]}
                                     com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                               :sha     "f7ef16dc3b8332b0d77bc0274578ad5270fbfedd"}}
+                                                               :sha     "b6b3193fcc42659d7e46ecd1884a228993441182"}}
                       :main-opts   ["-m" "cognitect.test-runner"]}}}

--- a/src/pour/core.clj
+++ b/src/pour/core.clj
@@ -1,12 +1,8 @@
 (ns pour.core
   (:require [edn-query-language.core :as eql]
-            [clojure.core.async :as ca])
+            [clojure.core.async :as ca]
+            [clojure.tools.logging :as log])
   (:import (clojure.lang Seqable)))
-
-(def ^{:private true
-       :dynamic true
-       :doc     "Results channel for resolvers per invocation of parse"}
-  *chan* nil)
 
 (defn seqy? [s]
   (and (not (:db/id s))
@@ -29,7 +25,8 @@
 (declare parse)
 
 (defn process-child [{:keys [env value child node-params]}]
-  (let [on-error (or (:on-error env) (fn [t]))
+  (log/info ::pc value)
+  (let [on-error (or (:on-error env) (fn [t] (log/error t)))
         resolved (try
                    (knit env (merge {:value value} child))
                    (catch Throwable t
@@ -43,16 +40,16 @@
                                                  matches-union)]
                           (reduce (fn [_ {:keys [union-key children params] :as uc}]
                                     (when (union-dispatch union-key value)
-                                      (reduced (parse env {:value    value
-                                                           :children children}))))
+                                      (reduced (ca/<! (parse env {:value    value
+                                                                  :children children})))))
                                   {}
                                   (:children child)))
                  :join (if (seqy? resolved)
                          (->> resolved
                               (keep (fn [v]
-                                      (parse env (merge {:value v} child))))
+                                      (ca/<! (parse env (merge {:value v} child)))))
                               (into []))
-                         (parse env (merge {:value resolved} child)))
+                         (ca/<! (parse env (merge {:value resolved} child))))
                  nil)
         result (if (nil? result)
                  (:default params)
@@ -60,42 +57,57 @@
         kname (or (:as params) key)]
     (if kname
       [kname result]
-      result)))
+      ;; change to ::nil
+      (if (nil? result)
+        ::nil
+        result))))
 
-(defn parse [env {:keys [value children]
+(defn parse [env {:keys       [value children key]
                   node-params :params}]
+  (prn ::k key)
   (when value
-    (binding [*chan* (ca/chan)]
-      (let [expected-results (count children)
+    (binding []
+      (let [chan (ca/chan)
+            expected-results (count children)
             wrapping? (nil? (get-in children [0 :key]))]
         (doseq [child children]
-          (ca/go (ca/>! *chan* (process-child {:env env
-                                               :value value
-                                               :child child
-                                               :node-params node-params}))))
-        (ca/<!! (ca/go-loop [result {}
-                             pending-results expected-results]
-                  (let [out (ca/<! *chan*)
-                        next-pending-count (dec pending-results)
-                        finished? (zero? next-pending-count)]
-                    (if wrapping?
-                      out
-                      (let [[k v] out
-                            next-result (if (nil? v)
-                                          result
-                                          (assoc result k v))]
-                        (if finished?
-                          next-result
-                          (recur next-result
-                                 next-pending-count)))))))))))
+          (ca/go (ca/>! chan (process-child {:env         env
+                                             :value       value
+                                             :child       child
+                                             :node-params node-params}))))
+
+        (ca/go-loop [result {}
+                     pending-results expected-results]
+          (let [next-pending-count (dec pending-results)
+                finished? (zero? next-pending-count)
+
+                next-result (try
+                              (let [out (ca/<! chan)
+                                    _ (log/info ::out out)]
+                                ;; change to ::nil sentinel
+                                (if wrapping?
+                                  (if (= ::nil out) nil out)
+                                  (let [[k v] out]
+                                    (if (nil? v)
+                                      result
+                                      (assoc result k v)))))
+                              (catch Throwable t
+                                (log/error ::uhoh t)
+                                result))]
+            (if finished?
+              next-result
+              (recur next-result
+                     next-pending-count))))))))
 
 (defn pour
   ([query value]
    (pour {} query value))
   ([env query value]
+   (prn ::hi)
    (let [env (update env :resolvers merge {:pipe pipe})
          ast (eql/query->ast query)]
      (->> {:value value}
           (merge ast)
-          (parse env)))))
+          (parse env)
+          (ca/<!!)))))
 

--- a/src/pour/core.clj
+++ b/src/pour/core.clj
@@ -1,9 +1,15 @@
 (ns pour.core
-  (:require [edn-query-language.core :as eql])
+  (:require [edn-query-language.core :as eql]
+            [clojure.core.async :as ca])
   (:import (clojure.lang Seqable)))
 
+(def ^{:private true
+       :dynamic true
+       :doc     "Results channel for resolvers per invocation of parse"}
+  *chan* nil)
+
 (defn seqy? [s]
-  (and (not (:db/id s)) ; ie, a datomic Entity or similar
+  (and (not (:db/id s))
        (not (map? s))
        (instance? Seqable s)))
 
@@ -12,65 +18,76 @@
 
 (defn knit [{:keys [resolvers] :as env}
             {:keys [dispatch-key value] :as node}]
-  (future (let [resolver (or (get resolvers dispatch-key)
-                             (fn default-resolver [_ _]
-                               (get value dispatch-key)))]
-            (resolver env (merge node {:value value})))))
+  (let [resolver (or (get resolvers dispatch-key)
+                     (fn default-resolver [_ _]
+                       (get value dispatch-key)))]
+    (resolver env (merge node {:value value}))))
 
 (defn- matches-union [key value]
   (boolean (key value)))
 
-(defn- process-map [m]
-  (if (map? m)
-    (->> m
-         (keep (fn [[k v]]
-                 (let [vv (if (future? v)
-                            (deref v)
-                            v)]
-                   (when (not (nil? vv))
-                     [k vv]))))
-         (into {}))
-    m))
+(declare parse)
 
-(defn parse [env {:keys [value children] :as node}]
+(defn process-child [{:keys [env value child node-params]}]
+  (let [on-error (or (:on-error env) (fn [t]))
+        resolved (try
+                   (knit env (merge {:value value} child))
+                   (catch Throwable t
+                     (on-error t)))
+        {:keys [type key params]} child
+        result (case type
+                 :prop resolved
+                 :union (let [union-dispatch (or (when-let [custom-dispatch (:union-dispatch node-params)]
+                                                   (and (symbol? custom-dispatch)
+                                                        (resolve custom-dispatch)))
+                                                 matches-union)]
+                          (reduce (fn [_ {:keys [union-key children params] :as uc}]
+                                    (when (union-dispatch union-key value)
+                                      (reduced (parse env {:value    value
+                                                           :children children}))))
+                                  {}
+                                  (:children child)))
+                 :join (if (seqy? resolved)
+                         (->> resolved
+                              (keep (fn [v]
+                                      (parse env (merge {:value v} child))))
+                              (into []))
+                         (parse env (merge {:value resolved} child)))
+                 nil)
+        result (if (nil? result)
+                 (:default params)
+                 result)
+        kname (or (:as params) key)]
+    (if kname
+      [kname result]
+      result)))
+
+(defn parse [env {:keys [value children]
+                  node-params :params}]
   (when value
-    (let [node-params (:params node)]
-      (->> children
-           (map (fn [child]
-                  {:pending (knit env (merge {:value value} child))
-                   :child child}))
-           (reduce (fn [acc {:keys [pending child]}]
-                     (let [resolved (deref pending)
-                           {:keys [type key params]} child
-                           v (condp = type
-                               :prop resolved
-                               :union (let [union-dispatch (or (when-let [custom-dispatch (:union-dispatch node-params)]
-                                                                 (and (symbol? custom-dispatch)
-                                                                      (resolve custom-dispatch)))
-                                                               matches-union)]
-                                        (reduce (fn [_ {:keys [union-key children params] :as uc}]
-                                                  (when (union-dispatch union-key value)
-                                                    (reduced (parse env {:value    value
-                                                                         :children children}))))
-                                                {}
-                                                (:children child)))
-                               :join (if (seqy? resolved)
-                                       (->> resolved
-                                            (keep (fn [v]
-                                                    (parse env (merge {:value v} child))))
-                                            (into []))
-                                       (parse env (merge {:value resolved} child)))
-                               nil)
-                           result (or v (:default params))
-                           kname (or (:as params) key)]
-                       (if (not (nil? result))
-                         (if kname
-                           (assoc acc kname result)
-                           result)
-                         acc)))
-                   {})
-           process-map))))
-
+    (binding [*chan* (ca/chan)]
+      (let [expected-results (count children)
+            wrapping? (nil? (get-in children [0 :key]))]
+        (doseq [child children]
+          (ca/go (ca/>! *chan* (process-child {:env env
+                                               :value value
+                                               :child child
+                                               :node-params node-params}))))
+        (ca/<!! (ca/go-loop [result {}
+                             pending-results expected-results]
+                  (let [out (ca/<! *chan*)
+                        next-pending-count (dec pending-results)
+                        finished? (zero? next-pending-count)]
+                    (if wrapping?
+                      out
+                      (let [[k v] out
+                            next-result (if (nil? v)
+                                          result
+                                          (assoc result k v))]
+                        (if finished?
+                          next-result
+                          (recur next-result
+                                 next-pending-count)))))))))))
 
 (defn pour
   ([query value]

--- a/test/pour/core_test.clj
+++ b/test/pour/core_test.clj
@@ -107,10 +107,13 @@
                             root)]
       (is (= (:aliased result)
              (:name root))))
-    (testing "default param should provide a value in the case the resolved value is nil"
-      (let [root {:name "person"}
-            result (pour/pour '[(:missing {:default 100})]
+    (testing "default param should provide a value in the case the resolved value is nil only, passing boolean false through"
+      (let [root {:name "person"
+                  :boolean false}
+            result (pour/pour '[(:missing {:default 100})
+                                (:boolean {:default true})]
                               root)]
+        (is (false? (:boolean result)))
         (is (= (:missing result)
                100))))))
 

--- a/test/pour/core_test.clj
+++ b/test/pour/core_test.clj
@@ -36,14 +36,15 @@
           env {:resolvers {:test/nil-resolver nil-resolver}}
           q '[:a
               :b
-              :c]
+              :c
+              :test/nil-resolver]
           v {:a 1 :b 2 :c 3}]
       (is (= (pour/pour env q v)
              {:a 1 :b 2 :c 3})))))
 
 (deftest pour
   (let [constant-resolver (fn [env node]
-                            :resolved-with-constant)
+                            ::constant)
         v {:bar     1
            :hi      :i-should-be-ignored
            :me      :also
@@ -58,7 +59,7 @@
             {:other [:foo1]}]
         env {:resolvers {:foo constant-resolver}}]
     (is (= (pour/pour env q v)
-           {:foo     :resolved-with-constant
+           {:foo     ::constant
             :hi      1
             :another {:thing :gah}
             :other   [{:foo1 :a}
@@ -119,7 +120,7 @@
       (is (= (:aliased result)
              (:name root))))
     (testing "default param should provide a value in the case the resolved value is nil only, passing boolean false through"
-      (let [root {:name "person"
+      (let [root {:name    "person"
                   :boolean false}
             result (pour/pour '[(:missing {:default 100})
                                 (:boolean {:default true})]

--- a/test/pour/core_test.clj
+++ b/test/pour/core_test.clj
@@ -26,9 +26,20 @@
       (is (not (pour/seqy? (d/entity (d/db conn) :db/ident)))))))
 
 (deftest nils
+  (is (nil? (pour/pour [:a :b] nil)) "nil values are skipped")
   (testing "nil values on provided keys should mean that the key is also not present in the output"
     (let [result (pour/pour [:a] {:a nil})]
-      (is (= {} result)))))
+      (is (= {} result))))
+  (testing "resolvers that return nil don't close the return channel"
+    (let [nil-resolver (fn [_ _]
+                         nil)
+          env {:resolvers {:test/nil-resolver nil-resolver}}
+          q '[:a
+              :b
+              :c]
+          v {:a 1 :b 2 :c 3}]
+      (is (= (pour/pour env q v)
+             {:a 1 :b 2 :c 3})))))
 
 (deftest pour
   (let [constant-resolver (fn [env node]

--- a/test/pour/core_test.clj
+++ b/test/pour/core_test.clj
@@ -133,17 +133,19 @@
 
 (deftest union-dispatch
   (testing "allow providing a custom union dispatch function as a parameter"
-    (let [root {:stuff [{:type :one
+    (let [root {:stuff [{:type      :one
+                         :id        123
+                         :product   :book
                          :something "hi"}
-                        {:type :two
+                        {:type    :two
+                         :id      456
+                         :product :book
                          :another "thing"}]}
-          result (pour/pour '[{(:stuff {:union-dispatch pour.core-test/custom-dispatch}) {:one   [:type
-                                                                                                  :something]
-                                                                                          :two   [:type
-                                                                                                  :another]}}]
+          result (pour/pour '[{(:stuff {:union-dispatch pour.core-test/custom-dispatch}) {:one [:type :something]
+                                                                                          :two [:type :another]}}]
                             root)]
       (is (= result
-             {:stuff [{:type :one
+             {:stuff [{:type      :one
                        :something "hi"}
-                      {:type :two
+                      {:type    :two
                        :another "thing"}]})))))


### PR DESCRIPTION
Futures are cheap, but they're not free - each carries a 512kb overhead (at least) for example, in typical JVMs.

This PR swaps out the futures for `core.async`.