### PR TITLE
Fix stalls with empty collections

### DIFF
--- a/src/pour/core.clj
+++ b/src/pour/core.clj
@@ -51,13 +51,15 @@
                                                             (ca/go ::nil))
                                                     (ca/<!))))
                                     :join (if (seqy? resolved)
-                                            (->> resolved
-                                                 (map (fn [v]
-                                                        (parse env (merge {:value v} child))))
-                                                 (ca/map (fn [& args]
-                                                           args))
-                                                 (ca/<!)
-                                                 (into []))
+                                            (if (empty? resolved)
+                                              nil
+                                              (->> resolved
+                                                   (map (fn [v]
+                                                          (parse env (merge {:value v} child))))
+                                                   (ca/map (fn [& args]
+                                                             args))
+                                                   (ca/<!)
+                                                   (into [])))
 
                                             (ca/<! (parse env (merge {:value resolved} child))))
                                     nil)


### PR DESCRIPTION
If a resolved value is an empty list, we would fail to create a channel for the parent to pull from, leading to a stall. 

This fix checks if a resolved value is empty and returns `nil` if so.