### PR TITLE
feature/view-macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,10 @@
 
 [![CircleCI](https://circleci.com/gh/clj-pour/pour.svg?style=svg)](https://circleci.com/gh/clj-pour/pour)
 
-## A nice strong cup of EQL.
-
-For a given function, and any nested calls, how do we know what data we need to satisfy that tree of functions?
-Can we ask the functions to tell us, and figure that out before we even call those functions?
-
-In a very specific way, `pour` tries to answer yes to those questions. Imagine `select-keys` where the first argument
-can be EQL, and the keys can either be accessors to a property on the value, or an invocation of a resolver on the value
-at that point. Further, imagine being able to build the EQL query up from the functions themselves, so that the
-description of the data a function needs is colocated with the function itself.
-
 Pour consists of a library for applying EQL queries to a value, and a tool for composing queries from functions
-annotated with a query (examples at the bottom), with the primary use case being functions that return hiccup (or
-similar).
+annotated with a query (examples at the bottom). The primary use case is for functions that return hiccup.
+
+Pour allows you to define custom resolvers that can be run at arbitrary points inside a query.
 
 It currently only supports JVM clojure but cljs support is under development.
 
@@ -58,8 +49,8 @@ If a requested key is not present in the value, it is not present in the output.
 The Arity-3 version can take an `env` argument in the first position.
 
 Here the user can specify an environment, or context, in which the query is operating.
-The user can supply a map of keys to resolver functions on the `resolvers` key on the env which, when present, will be used preferentially over direct access to the value,
-as in the example below.
+The user can supply a map of keys to resolver functions on the `resolvers` key on the env which, when present, will be
+used preferentially over direct access to the value, as in the example below.
 
 Resolvers are functions that take two arguments - `env` and the current `node` upon which it is operating.
 The env can contain arbitrary data, it is up to you. The node provides the value, and the EQL information about that
@@ -69,11 +60,10 @@ position in the query, eg params, type..
 (pour/pour
   {:now       (inst-ms (java.util.Date.))
    :resolvers {:days-ago-timestamp (fn [{:keys [now] :as env} {:keys [value params]
-                                                               :as ast-node}]
+                                                               :as node}]
                                      (let [days-ago (:days-ago params)
                                            days-ago-ms (* days-ago 24 60 60 1000)]
                                        (- now days-ago-ms)))}}
-
   '[(:days-ago-timestamp {:days-ago 7})
     :foo]
   {:foo :bar})
@@ -87,96 +77,6 @@ be - that's up to you - but we'll be building hiccup in the examples below.
 
 ```clojure
 
-(ns example
-  (:require [pour.core :as pour]
-            [pour.compose :as pc :refer [defcup]]))
-
-(defcup link
-  ; The metadata below defines the keys which the renderer requires
-  [:uri :title]
-  ; data - this is the value of the data resolved by pour at this level.
-  (fn render [{:keys [uri title]}]
-    [:a {:href uri} title]))
-
-(defcup nav
-  ; In the query below we provide a symbol, meaning that compose will try to look up
-  ; that symbol as a keyword in the provided renderers, and inline the query associated
-  ; with that renderer at this point in the query, before any data is resolved. That query
-  ; is joined onto the data provided by the left hand side (in this case, the data provided by
-  ; the `:app-nav` resolver, which is a collection of links) at data fetch time.
-  ; it's not currently possibly to inline a query without joining it on something.
-  ; As we're using symbols, we have to quote the query now.
-  [{:app-nav link}]}
-  ; For this component, we've declared a dependency on the `link` component above,
-  ; we don't actually know anything about what this component needs, beyond that we're joining
-  ; onto the values provided by :app-nav, all we do is declare that we're using this, and that
-  ; we'll be invoking it.
-  (fn render [{:keys [app-nav]}]
-    [:nav
-     (for [nav-link app-nav]
-       ;; The renderer is also available on the ::pc/renderer key of the resolved data as a function
-       (link nav-link))]))
-
-(defcup title
-  [:title]
-  (fn [{:keys [title]}]
-    [:section.main-title
-     [:img.logo {:src "/logo.jpg"}]
-     [:h1 title]]))
-
-(def app
-  ; As above, but beyond using symbols, we're also using parameters, meaning that again we have to
-  ; quote the query, or the list syntax used for parameters would be interpreted as a function call
-  ; again, we have to join the components onto something, so in this case we're just passing through
-  ; the root value.
-  ; normally, you'd be joining onto some value from the root, or a resolver of some sort.
-  ^{:query '[{(:pipe {:as :title}) atom/title}
-             {(:pipe {:as :navigation}) organism/nav}]}
-  (fn render [r {:keys [navigation title]}]
-    [:section.app
-     ((:organism/nav r) r navigation)
-     [:section.more-sections
-      ((:atom/title r) r title)
-      [:h2 "Heading 2"]]]))
-
-(defn renderers []
-  ; could be automated as you wish!
-  ; naming of keys is up to the user
-  {:atom/link    link
-   :atom/title   title
-   :organism/nav nav
-   :template/app app})
-
-(defn render-stuff []
-  (let [root-value {:title "Dynamic Title"}
-        resolvers {:app-nav (fn [env node]
-                              ; we're not using anything from the node or env here
-                              ; imagine we're looking up some data in a db, for example.
-                              [{:uri   "/"
-                                :title "Home"}
-                               {:uri   "/blog"
-                                :title "Blog"}
-                               {:uri   "/blog/1"
-                                :title "Article"}])}]
-    (pc/render ; fetch data function, partially applied with an environment
-                    (partial pour/pour {:resolvers resolvers})
-
-                    ; where to start, a root
-                    app
-                    ; the value which we join the harvested query from the root above
-                    root-value)))
-
-
-; Given all the plumbing above, we end up with a dynamically created query something like this:
-[{(:pipe {:as :title})
-  [:title]}
- {(:pipe {:as :navigation})
-  [{:app-nav
-    [:uri :title]}]}]
-
+:coming/soon!
 
 ```
-
-The examples are in the [dev/examples](https://github.com/clj-pour/pour/blob/master/dev/examples.clj) folder.
-
-PRs are welcome.

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
            org.clojure/core.async {:mvn/version "1.3.610"}
            aysylu/loom            {:mvn/version "1.0.2"}}
 
- :aliases {:provided {:extra-deps {org.clojure/clojure       {:mvn/version "1.10.1"}
+ :aliases {:provided {:extra-deps {org.clojure/clojure       {:mvn/version "1.10.3"}
                                    org.clojure/clojurescript {:mvn/version "1.10.773"}}}
            :test     {:extra-paths ["test" "dev"]
                       :extra-deps  {com.datomic/datomic-free  {:mvn/version "0.9.5697"

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,6 @@
 {:paths   ["src"]
  :deps    {edn-query-language/eql {:mvn/version "1.0.0"}
-           org.clojure/core.async {:mvn/version "1.3.610"}
-           aysylu/loom            {:mvn/version "1.0.2"}}
+           org.clojure/core.async {:mvn/version "1.3.610"}}
 
  :aliases {:provided {:extra-deps {org.clojure/clojure       {:mvn/version "1.10.3"}
                                    org.clojure/clojurescript {:mvn/version "1.10.773"}}}

--- a/dev/examples.clj
+++ b/dev/examples.clj
@@ -1,101 +1,57 @@
 (ns examples
-  (:require [pour.core :as pour]
-            [pour.compose :as compose]))
+  (:require [pour.compose :as compose :refer [defcup]]))
 
-(def link
-  ; The metadata below defines the keys which the renderer requires
-  ; In this case, we're just providing a vector of keys, so no need to quote the query
-  ^{:query [:uri :title]}
-  ; The args to the render function itself are as follows:
-  ; r - this is a map of all the renderers provided at the root. we use this to lookup
-  ; any nested renderers and invoke them, after the data has been resolved
-  ; data - this is the value of the data resolved by pour at this level.
-  (fn render [r {:keys [uri title]}]
+(defcup nav-link
+  [:uri :title]
+  (fn render [{:keys [uri title]}]
     [:a {:href uri} title]))
 
-(def nav
-  ; In the query below we provide a symbol, meaning that compose will try to look up
-  ; that symbol as a keyword in the provided renderers, and inline the query associated
-  ; with that renderer at this point in the query, before any data is resolved. That query
-  ; is joined onto the data provided by the left hand side (in this case, the data provided by
-  ; the `:app-nav` resolver, which is a collection of links) at data fetch time.
-  ; it's not currently possibly to inline a query without joining it on something.
-  ; As we're using symbols, we have to quote the query now.
-  ^{:query '[{:app-nav atom/link}]}
-  ; For this component, we've declared a dependency on the `atom/link` component above,
-  ; so we will have to look it up in the supplied `r` map of renderers to invoke it
-  ; with the data previously resolved.
-  ; we don't actually know anything about what this component needs, beyond that we're joining
-  ; onto the values provided by :app-nav, all we do is declare that we're using this, and that
-  ; we'll be invoking it.
-  (fn render [r {:keys [app-nav]}]
+(defcup nav
+  [{:resolve/app-nav nav-link}]
+  (fn render [{:resolve/keys [app-nav]}]
     [:nav
      (for [link app-nav]
-       ; This is a bit tortuous, but we look up the function and then invoke it with the renderers
-       ; map and the data.
-       ((:atom/link r) r link))]))
+       (nav-link link))]))
 
-(def title
-  ^{:query [:title]}
-  (fn [_ {:keys [title]}]
+(defcup app-title
+  [:title]
+  (fn [{:keys [title]}]
     [:section.main-title
      [:img.logo {:src "/logo.jpg"}]
      [:h1 title]]))
 
-(def app
-  ; As above, but beyond using symbols, we're also using parameters, meaning that again we have to
-  ; quote the query, or the list syntax used for parameters would be interpreted as a function call
-  ; again, we have to join the components onto something, so in this case we're just passing through
-  ; the root value.
-  ; normally, you'd be joining onto some value from the root, or a resolver of some sort.
-  ^{:query '[{(:pipe {:as :title}) atom/title}
-             {(:pipe {:as :navigation}) organism/nav}]}
-  (fn render [r {:keys [navigation title]}]
+(defcup app
+  [{(:pipe {:as :title}) app-title}
+   {(:pipe {:as :navigation}) nav}]
+  (fn render [{:keys [navigation title] :as v}]
     [:section.app
-     ((:organism/nav r) r navigation)
+     (nav navigation)
      [:section.more-sections
-      ((:atom/title r) r title)
-      [:h2 "Heading 2"]]]))
-
-(defn renderers []
-  ; could be automated as you wish!
-  ; naming of keys is up to the user
-  {:atom/link    link
-   :atom/title   title
-   :organism/nav nav
-   :template/app app})
+      (app-title title)]]))
 
 (defn render-stuff []
   (let [root-value {:title "Dynamic Title"}
-        resolvers {:app-nav (fn [env node]
-                              ; we're not using anything from the node or env here
-                              ; imagine we're looking up some data in a db, for example.
-                              [{:uri   "/"
-                                :title "Home"}
-                               {:uri   "/blog"
-                                :title "Blog"}
-                               {:uri   "/blog/1"
-                                :title "Article"}])}]
-    (compose/render ; fetch data function, partially applied with an environment
-                    (partial pour/pour {:resolvers resolvers})
+        resolvers {:resolve/app-nav (fn [env node]
+                                      ; we're not using anything from the node or env here
+                                      ; imagine we're looking up some data in a db, for example.
+                                      [{:uri   "/"
+                                        :title "Home"}
+                                       {:uri   "/blog"
+                                        :title "Blog"}
+                                       {:uri   "/blog/1"
+                                        :title "Article"}])}]
+    (compose/render {:resolvers resolvers} ;; env for pour - we provide any resolvers here
+                    app ;; root renderer, where to start
+                    root-value))) ;; value to start at
 
-                    ; all the renderers we're providing
-                    (renderers)
-
-                    ; where to start, a root
-                    :template/app
-
-                    ; the value which we join the harvested query from the root above
-                    root-value)))
-
-
-; Given all the plumbing above, we end up with a dynamically created query something like this:
-[(:renderer {:default :template/app})
- {(:pipe {:as :title}) [(:renderer {:default :atom/title}) :title]}
- {(:pipe {:as :navigation}) [(:renderer {:default :organism/nav})
-                             {:app-nav [(:renderer {:default :atom/link}) :uri :title]}]}]
-
-
+'[:section.app
+  [:nav ([:a {:href "/"} "Home"]
+         [:a {:href "/blog"} "Blog"]
+         [:a {:href "/blog/1"} "Article"])]
+  [:section.more-sections
+   [:section.main-title
+    [:img.logo {:src "/logo.jpg"}]
+    [:h1 "Dynamic Title"]]]]
 
 (comment
   ; output of the renderers

--- a/dev/examples.clj
+++ b/dev/examples.clj
@@ -1,5 +1,5 @@
 (ns examples
-  (:require [pour.compose :as compose :refer [defcup]]))
+  (:require [pour.compose :as pc :refer [defcup]]))
 
 (defcup nav-link
   [:uri :title]
@@ -20,38 +20,111 @@
      [:img.logo {:src "/logo.jpg"}]
      [:h1 title]]))
 
+;; Unions are supported
+
+(defcup summary-article
+  [:title :author :id]
+  (fn [{:keys [title author id]}]
+    [:section.article
+     [:h3 title " by " author]
+     [:a {:href (str "/author/" id)} "Read More"]]))
+
+(defcup summary-feed-item
+  [:title
+   {:articles summary-article}]
+  (fn [{:keys [title articles]}]
+    [:Section.summary
+     [:h2 title]
+     (for [article articles]
+       (summary-article article))]))
+
+(defcup video-feed-item
+  [:title
+   {:media [:src]}]
+  (fn [{:keys [title media]}]
+    [:section.video
+     [:h2 title]
+     [:video {:src (:src media)}]]))
+
+(defn matches-type [union-key value]
+  (= union-key
+     (:type value)))
+
+(defcup feed-renderer
+  [:title
+   {(:items {:union-dispatch matches-type}) {:video video-feed-item
+                                             :summary summary-feed-item}}]
+  (fn [{:keys [title items]}]
+    [:section.feed
+     [:h2 title]
+     [:div.items
+      (for [item items]
+        ;; In this case, we don't know which renderer was matched as part of the
+        ;; union resolution, so we lookup the matching renderer in the supplied data
+        ;; compose inlines a reference to the matching component under the ::pc/renderer
+        ;; key.
+        ((::pc/renderer item) item))]]))
+
 (defcup app
   [{(:pipe {:as :title}) app-title}
-   {(:pipe {:as :navigation}) nav}]
-  (fn render [{:keys [navigation title] :as v}]
+   {(:pipe {:as :navigation}) nav}
+   {:resolve/feed feed-renderer}]
+  (fn render [{:resolve/keys [feed]
+               :keys [navigation title]}]
     [:section.app
      (nav navigation)
      [:section.more-sections
-      (app-title title)]]))
+      (app-title title)]
+     (feed-renderer feed)]))
 
 (defn render-stuff []
-  (let [root-value {:title "Dynamic Title"}
-        resolvers {:resolve/app-nav (fn [env node]
-                                      ; we're not using anything from the node or env here
-                                      ; imagine we're looking up some data in a db, for example.
-                                      [{:uri   "/"
-                                        :title "Home"}
-                                       {:uri   "/blog"
-                                        :title "Blog"}
-                                       {:uri   "/blog/1"
-                                        :title "Article"}])}]
-    (compose/render {:resolvers resolvers} ;; env for pour - we provide any resolvers here
-                    app ;; root renderer, where to start
-                    root-value))) ;; value to start at
+  (let [root-value {:title "Dynamic Title"}]
+    (pc/render {;; env for pour - we provide any resolvers here
+                :resolvers {:resolve/app-nav (fn [env node]
+                                               ; we're not using anything from the node or env here
+                                               ; imagine we're looking up some data in a db, for example.
+                                               [{:uri   "/"
+                                                 :title "Home"}
+                                                {:uri   "/blog"
+                                                 :title "Blog"}
+                                                {:uri   "/blog/1"
+                                                 :title "Article"}])
+                            :resolve/feed    (fn [env node]
+                                               ;; Hetergenous data, feed is a good example of this
+                                               ;; Pour supports dispatch on type for unions
+                                               {:title "Your Feed"
+                                                :items [{:type  :video
+                                                         :title "Video item"
+                                                         :media {:src "https://some-url.com/video.mp4"}}
+                                                        {:type     :summary
+                                                         :title    "From authors you follow"
+                                                         :articles [{:id     1
+                                                                     :title  "Article 1"
+                                                                     :author "Nora"}
+                                                                    {:id     2
+                                                                     :title  "Article 2"
+                                                                     :author "Jim"}
+                                                                    {:id     3
+                                                                     :title  "Article 3"
+                                                                     :author "Lucas"}]}]})}}
+               ;; root renderer, where to start
+               app
+               ;; value to start at
+               root-value)))
 
 '[:section.app
-  [:nav ([:a {:href "/"} "Home"]
-         [:a {:href "/blog"} "Blog"]
-         [:a {:href "/blog/1"} "Article"])]
-  [:section.more-sections
-   [:section.main-title
-    [:img.logo {:src "/logo.jpg"}]
-    [:h1 "Dynamic Title"]]]]
+  [:nav ([:a {:href "/"} "Home"] [:a {:href "/blog"} "Blog"] [:a {:href "/blog/1"} "Article"])]
+  [:section.more-sections [:section.main-title [:img.logo {:src "/logo.jpg"}] [:h1 "Dynamic Title"]]]
+  [:section.feed
+   [:h2 "Your Feed"]
+   [:div.items
+    ([:section.video [:h2 "Video item"] [:video {:src "https://some-url.com/video.mp4"}]]
+     [:Section.summary
+      [:h2 "From authors you follow"]
+      ([:section.article [:h3 "Article 1" " by " "Nora"] [:a {:href "/author/1"} "Read More"]]
+       [:section.article [:h3 "Article 2" " by " "Jim"] [:a {:href "/author/2"} "Read More"]]
+       [:section.article [:h3 "Article 3" " by " "Lucas"] [:a {:href "/author/3"} "Read More"]])])]]]
+
 
 (comment
   ; output of the renderers

--- a/src/pour/compose.clj
+++ b/src/pour/compose.clj
@@ -73,15 +73,12 @@
 (defmacro view
   "View component"
   [query body]
-  (let [query# (first (next &form))
-        query-errors# (validate-query query)]
+  (let [query-errors# (validate-query query)]
     (when (seq query-errors#)
       (throw (ex-info "nuhuh" {:errors query-errors#})))
     `(with-meta ~body
-                {:query '~query})
-    #_`{::query (quote ~query)
-        ::fn    ~body}))
-
+                (merge (meta ~body)
+                       {:query '~query}))))
 
 (defn render
   "for a given map of `renderers`, invoke the renderer `root-renderer` with root value `root-value`

--- a/src/pour/compose.clj
+++ b/src/pour/compose.clj
@@ -69,13 +69,13 @@
               (not (vector? q))
               (conj)))))
 
-
 (defmacro view
   "View component"
   [query body]
   (let [query-errors# (validate-query query)]
     (when (seq query-errors#)
-      (throw (ex-info "nuhuh" {:errors query-errors#})))
+      (throw (ex-info "Query Error" {:type ::query-error
+                                     :errors query-errors#})))
     `(with-meta ~body
                 (merge (meta ~body)
                        {:query '~query}))))

--- a/src/pour/compose.clj
+++ b/src/pour/compose.clj
@@ -75,7 +75,7 @@
                                                 (swap! !unresolved-symbols# into qp-unresolveds#))
                                               (if mq#
                                                 (query (deref rvar#))
-                                                rvar#))
+                                                (deref rvar#)))
                                             (do
                                               ;; the passed symbol doesn't correspond to anything we can resolve
                                               ;; hence, we will expect it to be supplied at runtime

--- a/src/pour/compose.clj
+++ b/src/pour/compose.clj
@@ -125,6 +125,7 @@
          query (:query m)
          unresolveds (::unresolved m)
          renderers (::renderers env)]
+         ;; zip up the unresolveds with supplied renderers and error if something missing
      (with-meta (->> (pour/pour (or env {})
                                 query
                                 value)

--- a/src/pour/compose.clj
+++ b/src/pour/compose.clj
@@ -84,10 +84,6 @@
                                           query-part))
                                       query-literal)
         query-errors# (validate-query resolved-query#)
-        ident# (or (some-> (resolve &env cup-name)
-                           (symbol)
-                           (keyword))
-                   ::unknown)
         unresolveds# @!unresolved-symbols#]
     (when (seq query-errors#)
       (throw (ex-info "Query Error" {:type   ::query-error
@@ -96,7 +92,6 @@
        (with-meta ~body
                   (merge (meta ~body)
                          {::unresolved '~unresolveds#
-                          ::ident      ~ident#
                           :query       '~resolved-query#})))))
 
 (defn render

--- a/src/pour/compose.clj
+++ b/src/pour/compose.clj
@@ -1,8 +1,7 @@
 (ns pour.compose
   (:require [clojure.walk :as walk]
             [loom.graph :as g]
-            [loom.alg :as alg]
-            [clojure.set :as set]))
+            [loom.alg :as alg]))
 
 (defn query
   ([component]

--- a/src/pour/compose.clj
+++ b/src/pour/compose.clj
@@ -1,45 +1,23 @@
 (ns pour.compose
   (:require [clojure.walk :as walk]
-            [loom.graph :as g]
-            [loom.alg :as alg]
             [pour.core :as pour]))
 
 (defn query
-  ([component]
-   (:query (meta component)))
-  ([kw component]
-   (into [(list ::renderer {:default kw})
-          (list ::render-fn {:default component})]
-         (query component))))
+  [component]
+  (into [(list ::renderer {:default component})]
+        (:query (meta component))))
 
-(defn queries [renderers]
-  (->> renderers
-       (map (fn [[k v]] [k (query k v)]))
-       (into {})))
-
-(defn find-vars [query]
-  (filter symbol? (tree-seq coll? seq query)))
-
-(defn dep-map [config]
-  (zipmap (keys config)
-          (map #(set (find-vars (query %)))
-               (vals config))))
-
-(defn dep-order [config]
-  (-> config dep-map g/digraph alg/topsort reverse))
-
-(defn inject-query [queries query]
+(defn inject-query [renderers unprocessed-query]
   (walk/prewalk (fn [query-part]
                   (if (symbol? query-part)
-                    (get queries (keyword query-part) query-part)
+                    (let [component (get renderers (keyword query-part))
+                          {raw-query :query} (meta component)]
+                      (if raw-query
+                        (query component)
+                        (throw (ex-info (str "Missing renderer for " query-part)
+                                        {:query-part query-part}))))
                     query-part))
-                query))
-
-(defn resolve-all-deps [queries]
-  (reduce (fn [queries' k]
-            (update queries' k #(inject-query queries %)))
-          queries
-          (dep-order queries)))
+                unprocessed-query))
 
 (defn validate-query [q]
   (if-not (vector? q)
@@ -89,15 +67,14 @@
         resolved-query# (walk/prewalk (fn [query-part]
                                         (if (symbol? query-part)
                                           (if-let [rvar# (resolve &env query-part)]
-                                            (let [kw# (keyword (symbol rvar#))
-                                                  ;; pick up unresolved renderers from children
+                                            (let [;; pick up unresolved renderers from children
                                                   qp-unresolveds# (::unresolved (meta (deref rvar#)))
                                                   mq# (:query (meta (deref rvar#)))]
                                               ;; merge into accumulated unresolveds at this level
                                               (when (seq qp-unresolveds#)
                                                 (swap! !unresolved-symbols# into qp-unresolveds#))
                                               (if mq#
-                                                (query kw# (deref rvar#))
+                                                (query (deref rvar#))
                                                 rvar#))
                                             (do
                                               ;; the passed symbol doesn't correspond to anything we can resolve
@@ -107,6 +84,10 @@
                                           query-part))
                                       query-literal)
         query-errors# (validate-query resolved-query#)
+        ident# (or (some-> (resolve &env cup-name)
+                           (symbol)
+                           (keyword))
+                   ::unknown)
         unresolveds# @!unresolved-symbols#]
     (when (seq query-errors#)
       (throw (ex-info "Query Error" {:type   ::query-error
@@ -115,36 +96,22 @@
        (with-meta ~body
                   (merge (meta ~body)
                          {::unresolved '~unresolveds#
+                          ::ident      ~ident#
                           :query       '~resolved-query#})))))
 
-(defn render2
+(defn render
   ([renderer value]
-   (render2 {} renderer value))
+   (render {} renderer value))
   ([env renderer value]
    (let [m (meta renderer)
-         query (:query m)
          unresolveds (::unresolved m)
-         renderers (::renderers env)]
-         ;; zip up the unresolveds with supplied renderers and error if something missing
+         renderers (::renderers env)
+         query (cond->> (:query m)
+                        (seq unresolveds) (inject-query renderers))]
      (with-meta (->> (pour/pour (or env {})
                                 query
                                 value)
                      (renderer))
                 {:renderer renderer
                  :query    query}))))
-
-(defn render
-  "for a given map of `renderers`, invoke the renderer `root-renderer` with root value `root-value`
-  using the supplied `fetch` function"
-  [fetch renderers root-renderer root-value]
-  (let [queries (-> renderers queries resolve-all-deps)
-        renderer (if (fn? root-renderer)
-                   root-renderer
-                   (root-renderer renderers))
-        query (root-renderer queries)]
-    (with-meta (or (->> (fetch query root-value)
-                        (renderer))
-                   {})
-               {:renderer renderer
-                :query    query})))
 

--- a/src/pour/compose.clj
+++ b/src/pour/compose.clj
@@ -71,14 +71,14 @@
               (into join-errors)
 
               (seq invalid-accessors)
-              (conj {:error      "Query contains bad accessors"
+              (conj {:error             "Query contains bad accessors"
                      :invalid-accessors invalid-accessors})
 
               (not (every? (fn [[k v]]
                              (= 1 v))
                            freqs))
               (conj {:error      "duplicate identifiers found in query"
-                     :query q
+                     :query      q
                      :duplicates (into {} (keep (fn [[k v]] (when (> v 1) [k v])) freqs))})))))
 
 (defmacro view
@@ -86,7 +86,7 @@
   [query body]
   (let [query-errors# (validate-query query)]
     (when (seq query-errors#)
-      (throw (ex-info "Query Error" {:type ::query-error
+      (throw (ex-info "Query Error" {:type   ::query-error
                                      :errors query-errors#})))
     `(with-meta ~body
                 (merge (meta ~body)
@@ -97,7 +97,7 @@
   [cup-name query body]
   (let [query-errors# (validate-query query)]
     (when (seq query-errors#)
-      (throw (ex-info "Query Error" {:type ::query-error
+      (throw (ex-info "Query Error" {:type   ::query-error
                                      :errors query-errors#})))
     `(def ~cup-name
        (with-meta ~body

--- a/src/pour/compose.clj
+++ b/src/pour/compose.clj
@@ -7,7 +7,8 @@
   ([component]
    (:query (meta component)))
   ([kw component]
-   (into [(list ::renderer {:default kw})]
+   (into [(list ::renderer {:default kw})
+          (list ::render-fn {:default component})]
          (query component))))
 
 (defn queries [renderers]

--- a/src/pour/compose.clj
+++ b/src/pour/compose.clj
@@ -86,8 +86,11 @@
   (let [resolved-query# (walk/prewalk (fn [query-part]
                                         (if (symbol? query-part)
                                           (if-let [rvar# (resolve &env query-part)]
-                                            (let [kw# (keyword (symbol rvar#))]
-                                              (query kw# (deref rvar#)))
+                                            (let [kw# (keyword (symbol rvar#))
+                                                  mq# (:query (meta (deref rvar#)))]
+                                              (if mq#
+                                                (query kw# rvar#)
+                                                rvar#))
                                             query-part)
                                           query-part))
                                       query-literal)

--- a/src/pour/compose.clj
+++ b/src/pour/compose.clj
@@ -89,7 +89,7 @@
                                             (let [kw# (keyword (symbol rvar#))
                                                   mq# (:query (meta (deref rvar#)))]
                                               (if mq#
-                                                (query kw# rvar#)
+                                                (query kw# (deref rvar#))
                                                 rvar#))
                                             query-part)
                                           query-part))

--- a/src/pour/compose.clj
+++ b/src/pour/compose.clj
@@ -5,10 +5,9 @@
 
 (defn query
   ([component]
-   (or (::query component)
-       (:query (meta component))))
+   (:query (meta component)))
   ([kw component]
-   (into [(list :renderer {:default kw})]
+   (into [(list ::renderer {:default kw})]
          (query component))))
 
 (defn queries [renderers]
@@ -81,17 +80,6 @@
                      :query      q
                      :duplicates (into {} (keep (fn [[k v]] (when (> v 1) [k v])) freqs))})))))
 
-(defmacro view
-  "View component"
-  [query body]
-  (let [query-errors# (validate-query query)]
-    (when (seq query-errors#)
-      (throw (ex-info "Query Error" {:type   ::query-error
-                                     :errors query-errors#})))
-    `(with-meta ~body
-                (merge (meta ~body)
-                       {:query '~query}))))
-
 (defmacro defcup
   "Define a cup to pour."
   [cup-name query body]
@@ -103,7 +91,6 @@
        (with-meta ~body
                   (merge (meta ~body)
                          {:query '~query})))))
-
 
 (defn render
   "for a given map of `renderers`, invoke the renderer `root-renderer` with root value `root-value`

--- a/src/pour/core.clj
+++ b/src/pour/core.clj
@@ -111,9 +111,11 @@
   ([env query value]
    (let [env (update env :resolvers merge {:pipe pipe})
          ast (eql/query->ast query)]
-     (->> {:value value}
-          (merge ast)
-          (parse env)
-          (ca/<!!)))))
+     (if-not query
+       (throw (ex-info "Missing query" {:env env :query query}))
+       (->> {:value value}
+            (merge ast)
+            (parse env)
+            (ca/<!!))))))
 
 

--- a/src/pour/core.clj
+++ b/src/pour/core.clj
@@ -36,8 +36,7 @@
                                     :union (let [union-dispatch (or (when-let [custom-dispatch (:union-dispatch node-params)]
                                                                       (or (and (var? custom-dispatch) @custom-dispatch)
                                                                           (and (symbol? custom-dispatch)
-                                                                               (resolve custom-dispatch)
-                                                                               (deref (resolve custom-dispatch)))))
+                                                                               (some-> custom-dispatch resolve deref))))
                                                                     matches-union)]
                                              (if-not (fn? union-dispatch)
                                                (do (on-error (ex-info "Union-dispatch reference provided is not a function" {:params node-params}))

--- a/src/pour/core.clj
+++ b/src/pour/core.clj
@@ -1,7 +1,7 @@
 (ns pour.core
   (:require [edn-query-language.core :as eql]
             [clojure.core.async :as ca])
-  (:import (clojure.lang Seqable IFn)))
+  (:import (clojure.lang Seqable)))
 
 (defn seqy? [s]
   (and (not (:db/id s))

--- a/src/pour/core.clj
+++ b/src/pour/core.clj
@@ -34,7 +34,8 @@
                            result (case type
                                     :prop resolved
                                     :union (let [union-dispatch (or (when-let [custom-dispatch (:union-dispatch node-params)]
-                                                                      (or (and (var? custom-dispatch) @custom-dispatch)
+                                                                      (or (and (fn? custom-dispatch) custom-dispatch)
+                                                                          (and (var? custom-dispatch) @custom-dispatch)
                                                                           (and (symbol? custom-dispatch)
                                                                                (some-> custom-dispatch resolve deref))))
                                                                     matches-union)]

--- a/src/pour/core.clj
+++ b/src/pour/core.clj
@@ -1,7 +1,7 @@
 (ns pour.core
   (:require [edn-query-language.core :as eql]
             [clojure.core.async :as ca])
-  (:import (clojure.lang Seqable)))
+  (:import (clojure.lang Seqable IFn)))
 
 (defn seqy? [s]
   (and (not (:db/id s))
@@ -34,9 +34,10 @@
                            result (case type
                                     :prop resolved
                                     :union (let [union-dispatch (or (when-let [custom-dispatch (:union-dispatch node-params)]
-                                                                      (and (symbol? custom-dispatch)
-                                                                           (resolve custom-dispatch)
-                                                                           (deref (resolve custom-dispatch))))
+                                                                      (or (and (var? custom-dispatch) @custom-dispatch)
+                                                                          (and (symbol? custom-dispatch)
+                                                                               (resolve custom-dispatch)
+                                                                               (deref (resolve custom-dispatch)))))
                                                                     matches-union)]
                                              (if-not (fn? union-dispatch)
                                                (do (on-error (ex-info "Union-dispatch reference provided is not a function" {:params node-params}))

--- a/test/pour/compose_test.clj
+++ b/test/pour/compose_test.clj
@@ -1,7 +1,7 @@
 (ns pour.compose-test
   (:require [clojure.test :refer :all]
             [pour.core :as pour]
-            [pour.compose :refer [view] :as compose]))
+            [pour.compose :refer [defcup] :as c]))
 
 (defmacro eval-in-temp-ns [& forms]
   `(binding [*ns* *ns*]
@@ -11,57 +11,60 @@
      (eval
        '(do ~@forms))))
 
-(def r1
-  ^{:query '[:foo
-             :bar
-             {(:pipe {:as :r2}) r2}
-             {(:pipe {:as :r4}) r4}]}
-  (fn render [r {:keys [r4]
-                 {:keys [renderer other]} :r2}]
+(defcup r1
+  [:foo
+   :bar
+   {(:pipe {:as :r2}) r2}
+   {(:pipe {:as :r4}) r4}]
+  (fn render [r {:keys              [r4]
+                 {::c/keys [renderer]
+                  :keys    [other]} :r2}]
     [:section
      [:span renderer]
      [:span other]
      ((:r4 r) r r4)]))
 
-(def r2
-  ^{:query '[(:other {:default 1})]}
+(defcup r2
+  [(:other {:default 1})]
   (fn render [r {}]))
 
-(def r3
-  ^{:query '[]}
+(defcup r3
+  []
   (fn render [r {}]))
 
-(def r4 (view [:a :b]
-              (fn [r {:keys [a b renderer] :as v}]
-                [:div.r4 a b renderer])))
+(defcup r4 [:a :b]
+  (fn [r {::c/keys [renderer]
+          :keys    [a b] :as v}]
+    [:div.r4 a b renderer]))
 
 
 (deftest views
   (testing "invalid queries"
     (testing "query is not a vector"
-      (let [t (try (eval-in-temp-ns (view :foo
-                                          (fn [])))
+      (let [t (try (eval-in-temp-ns (defcup foo :foo
+                                      (fn [])))
                    (catch Throwable t
                      (-> t ex-cause ex-data)))]
         (is (= 1 (count (:errors t))))
         (is (= :foo (get-in t [:errors 0 :query])))))
     (testing "shadowed queries"
-      (let [t (try (eval-in-temp-ns (view [:a :a]
-                                          (fn [])))
+      (let [t (try (eval-in-temp-ns (defcup foo [:a :a]
+                                      (fn [])))
                    (catch Throwable t
                      (-> t ex-cause ex-data)))]
         (is (= 1 (count (:errors t))))
         (is (= {:a 2} (get-in t [:errors 0 :duplicates])))))
     (testing "invalid accessors"
-      (let [t (try (eval-in-temp-ns (view [#{}]
-                                          (fn [])))
+      (let [t (try (eval-in-temp-ns (defcup gensym [#{}]
+                                      (fn [])))
                    (catch Throwable t
                      (-> t ex-cause ex-data)))]
         (is (= 1 (count (:errors t))))
         (is (= (list #{}) (get-in t [:errors 0 :invalid-accessors])))))
     (testing "combined errors"
-      (let [t (try (eval-in-temp-ns (view [:a :a #{}]
-                                          (fn [])))
+      (let [t (try (eval-in-temp-ns (defcup foo
+                                      [:a :a #{}]
+                                      (fn [])))
                    (catch Throwable t
                      (-> t ex-cause ex-data)))]
         (is (= 2 (count (:errors t))))
@@ -69,12 +72,13 @@
         (is (= {:a 2} (get-in t [:errors 1 :duplicates]))))))
 
   (testing "Valid Queries"
-    (let [a (eval-in-temp-ns (view [:a
-                                    (:b {:as :c})
-                                    {:r2 r2}]
-                                   (fn [{:r2/keys [a]
-                                         :keys    [b]}]
-                                     [:div a])))
+    (let [a (eval-in-temp-ns (deref (defcup foo
+                                      [:a
+                                       (:b {:as :c})
+                                       {:r2 r2}]
+                                      (fn [{:r2/keys [a]
+                                            :keys    [c]}]
+                                        [:div a]))))
           {:keys [query]} (meta a)]
       (is (fn? a))
       (is (= query '[:a
@@ -83,23 +87,23 @@
 
 (deftest queries
   (let [fetch (partial pour/pour {})
-        result (compose/render fetch
-                               {:r1 r1
-                                :r2 r2
-                                :r3 r3
-                                :r4 r4}
-                               :r1
-                               {:a 1
-                                :b 2})]
-    (is (= '[(:renderer {:default :r1})
+        result (c/render fetch
+                         {:r1 r1
+                          :r2 r2
+                          :r3 r3
+                          :r4 r4}
+                         :r1
+                         {:a 1
+                          :b 2})]
+    (is (= '[(::c/renderer {:default :r1})
              :foo
              :bar
-             {(:pipe {:as :r2}) [(:renderer {:default :r2})
+             {(:pipe {:as :r2}) [(::c/renderer {:default :r2})
                                  (:other {:default 1})]}
-             {(:pipe {:as :r4}) [(:renderer {:default :r4})
+             {(:pipe {:as :r4}) [(::c/renderer {:default :r4})
                                  :a
                                  :b]}]
-            (:query (meta result))))
+           (:query (meta result))))
 
     (is (= [:section
             [:span :r2]

--- a/test/pour/compose_test.clj
+++ b/test/pour/compose_test.clj
@@ -171,4 +171,16 @@
            '[:div.r5 ([:div.one-r :one "hi"]
                       [:div.two-r :two "thing"])]))))
 
+(def av "av")
+(defcup a1
+  [(:foo {:default av})]
+  (fn [{:keys [foo] :as d}]
+    [:div foo]))
+
+
+(deftest inlining
+  (testing "default values"
+    (let [result (pc/render a1 {})]
+      (is (= [:div "av"]
+             result)))))
 

--- a/test/pour/compose_test.clj
+++ b/test/pour/compose_test.clj
@@ -3,14 +3,25 @@
             [pour.core :as pour]
             [pour.compose :refer [view] :as compose]))
 
+(defmacro eval-in-temp-ns [& forms]
+  `(binding [*ns* *ns*]
+     (in-ns (gensym))
+     (clojure.core/use 'clojure.core)
+     (clojure.core/use 'pour.compose)
+     (eval
+       '(do ~@forms))))
+
 (def r1
   ^{:query '[:foo
              :bar
-             {(:pipe {:as :r2}) r2}]}
-  (fn render [r {{:keys [renderer other]} :r2}]
+             {(:pipe {:as :r2}) r2}
+             {(:pipe {:as :r4}) r4}]}
+  (fn render [r {:keys [r4]
+                 {:keys [renderer other]} :r2}]
     [:section
      [:span renderer]
-     [:span other]]))
+     [:span other]
+     ((:r4 r) r r4)]))
 
 (def r2
   ^{:query '[(:other {:default 1})]}
@@ -20,29 +31,78 @@
   ^{:query '[]}
   (fn render [r {}]))
 
+(def r4 (view [:a :b]
+              (fn [r {:keys [a b renderer] :as v}]
+                [:div.r4 a b renderer])))
+
+
 (deftest views
-  (let [a (view [:a
-                 :c
-                 []
-                 #{}
-                 map
-                 #inst "2021"
-                 (:b {:as :c})
-                 {:r2 r2}]
-                (fn [{:r2/keys [a]
-                      :keys    [b]}]
-                  [:div a]))]
-    (is (= #{::compose/query
-             ::compose/fn}
-           (set (keys a))))))
+  (testing "invalid queries"
+    (testing "query is not a vector"
+      (let [t (try (eval-in-temp-ns (view :foo
+                                          (fn [])))
+                   (catch Throwable t
+                     (-> t ex-cause ex-data)))]
+        (is (= 1 (count (:errors t))))
+        (is (= :foo (get-in t [:errors 0 :query])))))
+    (testing "shadowed queries"
+      (let [t (try (eval-in-temp-ns (view [:a :a]
+                                          (fn [])))
+                   (catch Throwable t
+                     (-> t ex-cause ex-data)))]
+        (is (= 1 (count (:errors t))))
+        (is (= {:a 2} (get-in t [:errors 0 :duplicates])))))
+    (testing "invalid accessors"
+      (let [t (try (eval-in-temp-ns (view [#{}]
+                                          (fn [])))
+                   (catch Throwable t
+                     (-> t ex-cause ex-data)))]
+        (is (= 1 (count (:errors t))))
+        (is (= (list #{}) (get-in t [:errors 0 :invalid-accessors])))))
+    (testing "altogether"
+      (let [t (try (eval-in-temp-ns (view [:a :a #{}]
+                                          (fn [])))
+                   (catch Throwable t
+                     (-> t ex-cause ex-data)))]
+        (is (= 2 (count (:errors t))))
+        (is (= (list #{}) (get-in t [:errors 0 :invalid-accessors])))
+        (is (= {:a 2} (get-in t [:errors 1 :duplicates]))))))
+
+  (testing "Valid Queries"
+    (let [a (eval-in-temp-ns (view [:a
+                                    (:b {:as :c})
+                                    {:r2 r2}]
+                                   (fn [{:r2/keys [a]
+                                         :keys    [b]}]
+                                     [:div a])))
+          {:keys [query]} (meta a)]
+      (is (fn? a))
+      (is (= query '[:a
+                     (:b {:as :c})
+                     {:r2 r2}])))))
 
 (deftest queries
   (let [fetch (partial pour/pour {})
         result (compose/render fetch
                                {:r1 r1
                                 :r2 r2
-                                :r3 r3}
+                                :r3 r3
+                                :r4 r4}
                                :r1
-                               {})]
-    (is (= [:section [:span :r2/render] [:span 1]]
+                               {:a 1
+                                :b 2})]
+    (is (= '[(:renderer {:default :r1})
+             :foo
+             :bar
+             {(:pipe {:as :r2}) [(:renderer {:default :r2})
+                                 (:other {:default 1})]}
+             {(:pipe {:as :r4}) [(:renderer {:default :r4})
+                                 :a
+                                 :b]}]
+            (:query (meta result))))
+
+    (is (= [:section
+            [:span :r2]
+            [:span 1]
+            [:div.r4 1 2 :r4]]
            result))))

--- a/test/pour/compose_test.clj
+++ b/test/pour/compose_test.clj
@@ -11,10 +11,22 @@
      (eval
        '(do ~@forms))))
 
+(defcup r2
+  [{(:pipe {:as :r3}) r3}
+   (:other {:default 1})]
+  (fn render [r {}]))
+
+(defcup r3
+  []
+  (fn render [r {}]))
+
+
 (defcup r1
   [:foo
    :bar
+   ;; r2 below is a var, and so the macro will resolve at compile time
    {(:pipe {:as :r2}) r2}
+   ;; r4 here is a symbol, so this gets looked up at runtime
    {(:pipe {:as :r4}) r4}]
   (fn render [r {:keys              [r4]
                  {::c/keys [renderer]
@@ -24,19 +36,11 @@
      [:span other]
      ((:r4 r) r r4)]))
 
-(defcup r2
-  [(:other {:default 1})]
-  (fn render [r {}]))
-
-(defcup r3
-  []
-  (fn render [r {}]))
 
 (defcup r4 [:a :b]
   (fn [r {::c/keys [renderer]
           :keys    [a b] :as v}]
     [:div.r4 a b renderer]))
-
 
 (deftest views
   (testing "invalid queries"
@@ -99,6 +103,7 @@
              :foo
              :bar
              {(:pipe {:as :r2}) [(::c/renderer {:default :r2})
+                                 {(:pipe {:as :r3}) [(::c/renderer {:default :r3})]}
                                  (:other {:default 1})]}
              {(:pipe {:as :r4}) [(::c/renderer {:default :r4})
                                  :a

--- a/test/pour/compose_test.clj
+++ b/test/pour/compose_test.clj
@@ -20,16 +20,16 @@
    (:other {:default 1})]
   (fn render [r {}]))
 
-
-(defcup r4 [:a :b]
-  (fn [r {::c/keys [renderer]
-          :keys    [a b] :as v}]
+(defcup r4
+  [:a :b]
+  (fn [{::c/keys [renderer]
+        :keys    [a b] :as v}]
     [:div.r4 a b renderer]))
 
 (defcup r1
   [:foo
    :bar
-   ;; r2 & r4 below is a var, and so the macro will resolve at compile time
+   ;; r2 & r4 below is a var, and so the macro will resolve & inline queries at compile time
    {(:pipe {:as :r2}) r2}
    {(:pipe {:as :r4}) r4}]
   (fn render [r {:keys              [r4]
@@ -38,7 +38,7 @@
     [:section
      [:span renderer]
      [:span other]
-     ((:r4 r) r r4)]))
+     (pour.compose-test/r4 r4)]))
 
 (deftest views
   (testing "invalid queries"

--- a/test/pour/compose_test.clj
+++ b/test/pour/compose_test.clj
@@ -6,7 +6,7 @@
 (def r1
   ^{:query '[:foo
              :bar
-             {(:pipe {:as :r2}) r2/render}]}
+             {(:pipe {:as :r2}) r2}]}
   (fn render [r {{:keys [renderer other]} :r2}]
     [:section
      [:span renderer]
@@ -20,14 +20,17 @@
   ^{:query '[]}
   (fn render [r {}]))
 
-(def r4)
-
 (deftest views
   (let [a (view [:a
-                 (:b {:as c})
-                 {:r2 r2/render}]
+                 :c
+                 []
+                 #{}
+                 map
+                 #inst "2021"
+                 (:b {:as :c})
+                 {:r2 r2}]
                 (fn [{:r2/keys [a]
-                      :keys [b]}]
+                      :keys    [b]}]
                   [:div a]))]
     (is (= #{::compose/query
              ::compose/fn}
@@ -36,9 +39,9 @@
 (deftest queries
   (let [fetch (partial pour/pour {})
         result (compose/render fetch
-                               {:r1        r1
-                                :r2/render r2
-                                :r3/render r3}
+                               {:r1 r1
+                                :r2 r2
+                                :r3 r3}
                                :r1
                                {})]
     (is (= [:section [:span :r2/render] [:span 1]]

--- a/test/pour/compose_test.clj
+++ b/test/pour/compose_test.clj
@@ -1,7 +1,7 @@
 (ns pour.compose-test
   (:require [clojure.test :refer :all]
             [pour.core :as pour]
-            [pour.compose :as compose]))
+            [pour.compose :refer [view] :as compose]))
 
 (def r1
   ^{:query '[:foo
@@ -20,6 +20,18 @@
   ^{:query '[]}
   (fn render [r {}]))
 
+(def r4)
+
+(deftest views
+  (let [a (view [:a
+                 (:b {:as c})
+                 {:r2 r2/render}]
+                (fn [{:r2/keys [a]
+                      :keys [b]}]
+                  [:div a]))]
+    (is (= #{::compose/query
+             ::compose/fn}
+           (set (keys a))))))
 
 (deftest queries
   (let [fetch (partial pour/pour {})

--- a/test/pour/compose_test.clj
+++ b/test/pour/compose_test.clj
@@ -59,7 +59,7 @@
                      (-> t ex-cause ex-data)))]
         (is (= 1 (count (:errors t))))
         (is (= (list #{}) (get-in t [:errors 0 :invalid-accessors])))))
-    (testing "altogether"
+    (testing "combined errors"
       (let [t (try (eval-in-temp-ns (view [:a :a #{}]
                                           (fn [])))
                    (catch Throwable t

--- a/test/pour/compose_test.clj
+++ b/test/pour/compose_test.clj
@@ -40,6 +40,8 @@
      [:span other]
      (pour.compose-test/r4 r4)]))
 
+
+
 (deftest views
   (testing "invalid queries"
     (testing "query is not a vector"
@@ -86,6 +88,34 @@
       (is (= query '[:a
                      (:b {:as :c})
                      {:r2 r2}])))))
+
+(defn custom-dispatch [union-key value]
+  (= (:type value) union-key))
+
+(defcup r5
+  [{(:stuff {:union-dispatch custom-dispatch}) {:one [:type :something]
+                                                :two [:type :another]}}]
+  (fn [r {:as d}]
+    [:div.r5 d]))
+
+(deftest unions
+  (let [value {:stuff [{:type      :one
+                        :id        123
+                        :product   :book
+                        :something "hi"}
+                       {:type    :two
+                        :id      456
+                        :product :book
+                        :another "thing"}]}
+        fetch (partial pour/pour {})
+        result (c/render fetch
+                         {:r5 r5}
+                         :r5
+                         value)]
+    (is (= [:div.r5 {:pour.compose/renderer :r5, :stuff [{:type :one, :something "hi"} {:type :two, :another "thing"}]}]
+           result))))
+
+
 
 (deftest queries
   (let [fetch (partial pour/pour {})

--- a/test/pour/core_test.clj
+++ b/test/pour/core_test.clj
@@ -29,6 +29,14 @@
   nil)
 
 (deftest nils
+  (testing "missing query should throw"
+    (let [!e (atom nil)]
+      (try
+        (pour/pour nil nil)
+        (catch Throwable e
+          (reset! !e e)))
+      (is (instance? Throwable @!e))
+      (is (= (ex-message @!e) "Missing query"))))
   (is (= nil (pour/pour [:a :b] nil)) "nil values are skipped")
   (testing "nil values on provided keys should mean that the key is also not present in the output"
     (let [result (pour/pour [:a] {:a nil})]


### PR DESCRIPTION
Fixes https://github.com/clj-pour/pour/issues/17

Adding a view macro that performs some validation as a first step on the supplied query, and means you don't have to worry about quoting when writing a query. 

Allows resolving queries at compile time, by checking if the right hand side of a join is a var, and inlining the query associated with that var at that position. 

- adds `view` or `defcup` macro
- retire dependency on `loom`, don't walk, resolve and sort deps on each invocation
- adds basic query validation
- adds tests for validation
- allow compilation to cljs, by not requiring symbols to be passed around at runtime 
- removing need for first `r` parameter by passing render-fns as part of resolved data. (still not sure about the shape of this yet, but it's definitely convenient)
- upgrading `:renderer` ident to a namespaced kw from the library
- adding `::render-fn` entry to resolved data, providing the actual rendering function. this is super handy in unions, and works 
- allow passing an actual reference to a `cup` to pour in the query, instead of putting symbols in there

```clj

(defcup 
  my-thing
  [:a :b {(:foo {:as :c}) other/thing}]
  (fn [{:keys [a b c]
    (prn a b c}))

```

### Todo

- [ ] update `README`
- [x] finalise shape of `::render-fn` stuff. is there another way to get these functions in there somehow?
- [x] do we need the `::renderer` key if we're passing the function around?
- [x] pass var instead of fn, so reloading works properly.
- [x] allow overriding a specific renderer / query at runtime
- [x] retire `r` parameter to renderers
